### PR TITLE
Moved grocery basket from page component location to header component for better responsiveness.

### DIFF
--- a/src/components/GroceryBasket/GroceryBasket.module.css
+++ b/src/components/GroceryBasket/GroceryBasket.module.css
@@ -40,12 +40,9 @@
 /*Basket image styles start*/
 
 .basketImage{
-    position: fixed;
-    top: 10px;
-    right: 40px;
-    width: 75px;
+    max-width: 75px;
+    width: 100%;
     height: 75px;
-    z-index: 101;
 }
 .basketImage img{
     width: 100%;

--- a/src/components/GroceryBasket/GroceryBasket.tsx
+++ b/src/components/GroceryBasket/GroceryBasket.tsx
@@ -16,7 +16,8 @@ const GroceryBasket:FC<GroceryBasket> = ({visible, setVisible}) => {
     }
 
     return (
-        visible ?
+        <>
+            {visible &&
         <div className={cl.wrapper} onClick={wrapperClickHandler}>
             <div className={cl.container} onClick={(e:React.MouseEvent<HTMLDivElement>)=>e.stopPropagation()}>
                 <div className={cl.basket}>
@@ -25,10 +26,11 @@ const GroceryBasket:FC<GroceryBasket> = ({visible, setVisible}) => {
                 </div>
             </div>
         </div>
-            :
+            }
             <div className={cl.basketImage}>
                 <img onClick={()=>setVisible(true)} src={require('../../assets/images/basket.png')} alt="basket"/>
             </div>
+        </>
     );
 };
 

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -22,6 +22,11 @@
     justify-content: space-between;
     align-items: center;
 }
+.header__linksContainer{
+    display: flex;
+    align-items: center;
+    gap: 30px;
+}
 .header__links{
     display: flex;
     gap: 40px;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,20 +1,25 @@
-import React, {FC} from 'react';
+import React, {FC, useState} from 'react';
 import cl from './Header.module.css'
 import headerLogo from './../../assets/icons/header-logo.svg'
 import {Link} from "react-router-dom";
+import GroceryBasket from "../GroceryBasket/GroceryBasket";
 
 const Header:FC = () => {
+    const [visible, setVisible] = useState<boolean>(false);
     return (
         <header className={cl.header}>
             <div className={cl.header__content}>
                 <div className={cl.header__logo}><img src={headerLogo} alt="Header logo"/></div>
-                <ul className={cl.header__links}>
-                    <li className={cl.header__link}><Link to={'/'}>Home</Link></li>
-                    <li className={cl.header__link}><Link to={'#'}>About</Link></li>
-                    <li className={cl.header__link}><Link to={'#'}>Menu</Link></li>
-                    <li className={cl.header__link}><Link to={'#'}>Services</Link></li>
-                    <li className={cl.header__link}><Link to={'#'}>Contact</Link></li>
-                </ul>
+                <div className={cl.header__linksContainer}>
+                    <ul className={cl.header__links}>
+                        <li className={cl.header__link}><Link to={'/'}>Home</Link></li>
+                        <li className={cl.header__link}><Link to={'#'}>About</Link></li>
+                        <li className={cl.header__link}><Link to={'#'}>Menu</Link></li>
+                        <li className={cl.header__link}><Link to={'#'}>Services</Link></li>
+                        <li className={cl.header__link}><Link to={'#'}>Contact</Link></li>
+                    </ul>
+                    <GroceryBasket visible={visible} setVisible={setVisible}/>
+                </div>
             </div>
         </header>
     );

--- a/src/components/SpecialFoodCard/SpecialFoodCard.module.css
+++ b/src/components/SpecialFoodCard/SpecialFoodCard.module.css
@@ -103,6 +103,7 @@
     width: 70%;
     height: 70%;
     position: relative;
+    z-index: 2;
 }
 .card__secondImageWrapper{
     position: absolute;

--- a/src/components/pages/Home/Home.tsx
+++ b/src/components/pages/Home/Home.tsx
@@ -1,10 +1,8 @@
-import React, {useState} from 'react';
+import React from 'react';
 import FoodCard from "../../FoodCard/FoodCard";
 import SpecialFoodCard from "../../SpecialFoodCard/SpecialFoodCard";
-import GroceryBasket from "../../GroceryBasket/GroceryBasket";
 
 const Home = () => {
-    const [visible, setVisible] = useState<boolean>(false);
     return (
         <div>
             <FoodCard
@@ -21,7 +19,6 @@ const Home = () => {
                 specialImage={'dumplings.png'}
                 secondaryImage={'dumplings.png'}
             />
-            <GroceryBasket visible={visible} setVisible={setVisible}/>
         </div>
     );
 };


### PR DESCRIPTION
While we are squeezing our screen, due to groceries css position: fixed, it starts to cover header links if we position it right to header. On the other hand if we position it in the page component, it can cover elements on the oher pages, for example food card in the menu, so i decided to position basket in header component using flex-box. As a result our component will never cover other elemnts, and will be more responsive.